### PR TITLE
For H264 encoding use the GUID

### DIFF
--- a/src/NvPipe.cu
+++ b/src/NvPipe.cu
@@ -663,6 +663,10 @@ private:
                 encodeConfig.rcParams.maxBitRate = encodeConfig.rcParams.averageBitRate;
                 encodeConfig.rcParams.vbvInitialDelay = encodeConfig.rcParams.vbvBufferSize;
             }
+            
+            // setting Profile baseline
+            if (this->codec == NVPIPE_H264)
+                encodeConfig.profileGUID = NV_ENC_H264_PROFILE_BASELINE_GUID;
 
             encoder->CreateEncoder(&initializeParams);
         }


### PR DESCRIPTION
There is a commit in Sight Framework which is here https://github.com/benjha/NvPipe/commit/944fbee21c03ab373b97b85c734d032262d0dd07

Is there any reason why this code change cannot be in NvPipe?

If this pull request is not acceptable, would it be more acceptable if it was an optional configuration setting as part of the Encoder class?