### PR TITLE
Improve the NvCodecUtils check() for HRESULT

### DIFF
--- a/src/Video_Codec_SDK_9.0.20/Samples/Utils/NvCodecUtils.h
+++ b/src/Video_Codec_SDK_9.0.20/Samples/Utils/NvCodecUtils.h
@@ -11,6 +11,8 @@
 
 #pragma once
 #include <iomanip>
+#include <ios>
+#include <sstream>
 #include <chrono>
 #include <sys/stat.h>
 #include <assert.h>
@@ -84,7 +86,9 @@ inline bool check(NVENCSTATUS e, int iLine, const char *szFile) {
 #ifdef _WINERROR_
 inline bool check(HRESULT e, int iLine, const char *szFile) {
     if (e != S_OK) {
-        LOG(FATAL) << "HRESULT error 0x" << (void *)e << " at line " << iLine << " in file " << szFile;
+        std::stringstream stream;
+        stream << std::hex << std::uppercase << e;
+        LOG(FATAL) << "HRESULT error 0x" << stream.str() << " at line " << iLine << " in file " << szFile;
         return false;
     }
     return true;


### PR DESCRIPTION
This change uses a std::stringstream to print the HRESULT as
a hexadecimal value instead of streaming out the HRESULT cast
to a void pointer.  Casting a HRESULT to a void pointer is
problematic since sizeof(HRESULT) is 4, also for x64.

Before this change the check() function log output for x64
could e.g. be:
"HRESULT error 0xFFFFFFFF8000FFFF at line ..."

After this change the corresponding output is:
"HRESULT error 0x8000FFFF at line ..."

This change also fixes the following Visual C++ warning for x64:
warning C4312: 'type cast': conversion from 'HRESULT' to 'void *' of greater size

This change adds the inclusion of two additional header files.
This will not pull inn any new code since these headers were
already included (transitively) before: Logger.h already includes
<sstream> and <iostream>, and the latter in turn includes <ios>.